### PR TITLE
Implement multibus CAN@net

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 * Load layout when `.FPS` is instantiated.
 * Improved logging system.
 * Added initial actor features.
+* Initial implementation of the ``CAN@net`` bus.
 
 * :release:`0.1.0 <2018-10-10>`
 * Initial documentation.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changelog
 * Added initial actor features.
 * :feature:`9` Initial implementation of the ``CAN@net`` bus.
 * Renamed ``interfaces -> profiles`` in configuration.
+* :bug:`11` Fix endianess of firmware version.
 
 * :release:`0.1.0 <2018-10-10>`
 * Initial documentation.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,8 @@ Changelog
 * Load layout when `.FPS` is instantiated.
 * Improved logging system.
 * Added initial actor features.
-* Initial implementation of the ``CAN@net`` bus.
+* :feature:`9` Initial implementation of the ``CAN@net`` bus.
+* Renamed ``interfaces -> profiles`` in configuration.
 
 * :release:`0.1.0 <2018-10-10>`
 * Initial documentation.

--- a/docs/sphinx/api.rst
+++ b/docs/sphinx/api.rst
@@ -42,3 +42,11 @@ jaeger.utils
 .. automodule:: jaeger.utils.utils
    :members:
    :show-inheritance:
+
+
+jaeger.interfaces
+-----------------
+
+.. automodule:: jaeger.interfaces.cannet
+   :members:
+   :show-inheritance:

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-04-26 23:16:16
+# @Last modified time: 2019-06-17 14:05:23
 
 import os
 import shutil
@@ -130,7 +130,7 @@ autodoc_default_options = {
 }
 
 napoleon_use_rtype = False
-napoleon_use_ivar = False
+napoleon_use_ivar = True
 
 rst_epilog = """
 """

--- a/docs/sphinx/shatterdome.rst
+++ b/docs/sphinx/shatterdome.rst
@@ -90,7 +90,7 @@ This will create a new CAN bus (accessible as `.FPS.bus`) using the ``default`` 
 Initialisation
 ^^^^^^^^^^^^^^
 
-Once we have created a `.FPS` object we'll need to initialise it by calling and awaiting `.FPS.initialise`. This will issue two broadcast commands: `~.commands.GetStatus` and `.commands.GetFirmwareVersion`. The replies to these commands are used to determine which positioners are connected and sets their status. Each one of the positioners that have replied are subsequently initialised as detailed in :ref:`positioner-initialise`.
+Once we have created a `.FPS` object we'll need to initialise it by calling and awaiting `.FPS.initialise`. This will issue two broadcast commands: `~.commands.GetStatus` and `~.commands.GetFirmwareVersion`. The replies to these commands are used to determine which positioners are connected and sets their status. Each one of the positioners that have replied are subsequently initialised as detailed in :ref:`positioner-initialise`.
 
 Sending commands
 ^^^^^^^^^^^^^^^^

--- a/python/jaeger/can.py
+++ b/python/jaeger/can.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-18 16:20:25
+# @Last modified time: 2019-06-18 16:54:37
 
 import asyncio
 import binascii
@@ -136,7 +136,11 @@ class JaegerCAN(object):
         for channel in channels:
             log.info(f'creating interface {interface_name}, '
                      f'channel={channel!r}, args={args}, kwargs={kwargs}.')
-            self.interfaces.append(InterfaceClass(channel, *args, **kwargs))
+            try:
+                self.interfaces.append(InterfaceClass(channel, *args, **kwargs))
+            except Exception as ee:
+                raise ConnectionRefusedError(
+                    f'connection to {interface_name}:{channel} failed: {ee}.')
 
         self._start_notifier()
 

--- a/python/jaeger/can.py
+++ b/python/jaeger/can.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-17 16:57:37
+# @Last modified time: 2019-06-17 17:03:32
 
 import asyncio
 import binascii
@@ -26,7 +26,7 @@ from jaeger.commands import CommandID
 from jaeger.maskbits import CommandStatus
 
 
-__ALL__ = ['JaegerCAN', 'JaegerReaderCallback', 'INTERFACES']
+__ALL__ = ['JaegerCAN', 'CANnetInterface', 'JaegerReaderCallback', 'INTERFACES']
 
 
 #: Accepted CAN interfaces with the format.

--- a/python/jaeger/can.py
+++ b/python/jaeger/can.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-17 17:21:14
+# @Last modified time: 2019-06-18 11:00:19
 
 import asyncio
 import binascii
@@ -116,9 +116,6 @@ class JaegerCAN(object):
     notifier : can.Notifier
         A `can.Notifier` instance that processes messages from the list
         of buses, asynchronously.
-    running_commands : dict
-        Commands currently running ordered by ``positioner_id`` (or zero for
-        broadcast).
 
     """
 
@@ -147,6 +144,8 @@ class JaegerCAN(object):
         self.command_queue = asyncio.Queue(maxsize=100)
         self._command_queue_task = self.loop.create_task(self._process_queue())
 
+        #: dict: Commands currently running ordered by ``positioner_id``
+        #: (or zero forbroadcast).
         self.running_commands = collections.defaultdict(dict)
 
     def _start_notifier(self):

--- a/python/jaeger/can.py
+++ b/python/jaeger/can.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-05-08 15:22:53
+# @Last modified time: 2019-06-17 16:57:37
 
 import asyncio
 import binascii
@@ -26,14 +26,32 @@ from jaeger.commands import CommandID
 from jaeger.maskbits import CommandStatus
 
 
-__ALL__ = ['JaegerCAN', 'JaegerReaderCallback', 'VALID_INTERFACES']
+__ALL__ = ['JaegerCAN', 'JaegerReaderCallback', 'INTERFACES']
 
 
-#: Accepted CAN interfaces
-VALID_INTERFACES = {'slcan': can.interfaces.slcan.slcanBus,
-                    'socketcan': can.interfaces.socketcan.SocketcanBus,
-                    'virtual': can.interfaces.virtual.VirtualBus,
-                    'cannet': jaeger.interfaces.cannet.CANNetBus}
+#: Accepted CAN interfaces with the format.
+INTERFACES = {
+    'slcan': {
+        'class': can.interfaces.slcan.slcanBus,
+        'multichannel': False,
+        'multibus': False
+    },
+    'socketcan': {
+        'class': can.interfaces.socketcan.SocketcanBus,
+        'multichannel': False,
+        'multibus': False
+    },
+    'virtual': {
+        'class': can.interfaces.virtual.VirtualBus,
+        'multichannel': False,
+        'multibus': False
+    },
+    'cannet': {
+        'class': jaeger.interfaces.cannet.CANNetBus,
+        'multichannel': True,
+        'multibus': True
+    }
+}
 
 
 class JaegerReaderCallback(can.Listener):
@@ -64,71 +82,80 @@ class JaegerReaderCallback(can.Listener):
 
 
 class JaegerCAN(object):
-    """Returns an expanded CAN interface.
+    """A CAN interface with a command queue and reply handling.
 
-    Returns a CAN bus instance subclassing from the appropriate `python-can`_
-    interface (ultimately a subclass of `~can.BusABC` itself).
+    Provides support for multi-channel CAN networks, with each channel being
+    able to host more than one bus. In general, a new instance of `.JaegerCAN`
+    is create via the `~.JaegerCAN.from_profile` classmethod.
 
     Parameters
     ----------
-    interface : str
-        One of `~jaeger.can.VALID_INTERFACES`.
-        Defines the type of interface to use and the class from
-        `python-can <https://python-can.readthedocs.io/en/stable/>`_
-        to import.
+    interface_name : str
+        One of `~jaeger.can.INTERFACES`. Defines the
+        `python-can <https://python-can.readthedocs.io/en/stable/>`_ interface
+        to use.
+    channels : list
+        A list of channels to be used to instantiate the interfaces.
+    loop
+        The event loop to use.
     args,kwargs
-        Arguments and keyword arguments to pass to the interface when
-        initialising it (e.g., the channel, baudrate, etc).
+        Arguments and keyword arguments to pass to the interfaces when
+        initialising it (e.g., port, baudrate, etc).
 
-    Returns
-    -------
-    bus : `.JaegerCAN`
-        A bus class instance,
+    Attributes
+    ----------
+    command_queue : asyncio.Queue
+        Queue of messages to be sent to the bus. The messages are sent as
+        soon as the bus has finished processing any commands with the same
+        ``command_id`` and ``positioner_id``.
+    interfaces
+        A list of `python-can`_ interfaces, one for each of the ``channels``.
+    listener : JaegerReaderCallback
+        A `.JaegerReaderCallback` instance that runs a callback when
+        a new message is received from the bus.
+    notifier : can.Notifier
+        A `can.Notifier` instance that processes messages from the list
+        of buses, asynchronously.
+    running_commands : dict
+        Commands currently running ordered by ``positioner_id`` (or zero for
+        broadcast).
 
     """
 
-    def __new__(cls, interface, *args, **kwargs):
-        """Dynamically subclasses from the correct CAN interface."""
-
-        assert interface in VALID_INTERFACES, f'invalid interface {interface!r}'
-
-        log.debug(f'starting bus with interface {interface}, args={args!r}, kwargs={kwargs!r}')
-
-        interface_class = VALID_INTERFACES[interface]
-
-        jaeger_class = type('JaegerCAN', (interface_class, JaegerCAN), {})
-
-        jaeger_instance = interface_class.__new__(jaeger_class)
-
-        interface_class.__init__(jaeger_instance, *args, **kwargs)
-        JaegerCAN.__init__(jaeger_instance, *args, **kwargs)
-
-        return jaeger_instance
-
-    def __init__(self, *args, loop=None, **kwargs):
-
-        self.command_queue = asyncio.Queue(maxsize=10)
-
-        #: Commands currently running ordered positioner_id (or zero for broadcast).
-        self.running_commands = collections.defaultdict(dict)
+    def __init__(self, interface_name, channels, *args, loop=None, **kwargs):
 
         self.loop = loop if loop is not None else asyncio.get_event_loop()
 
-        #: A `.JaegerReaderCallback` instance that calls a callback when
-        #: a new message is received from the bus.
-        self.listener = JaegerReaderCallback(self._process_reply, loop=self.loop)
+        assert interface_name in INTERFACES, f'invalid interface {interface_name}.'
+        self.interface_name = interface_name
 
-        #: A `~.can.Notifier` instance that processes messages from
-        #: the bus asynchronously.
-        self.notifier = can.notifier.Notifier(self, [self.listener], loop=self.loop)
+        InterfaceClass = INTERFACES[interface_name]['class']
+        self.multichannel = INTERFACES[interface_name]['multichannel']
+        self.multibus = INTERFACES[interface_name]['multibus']
 
-        #: Queue of messages to be sent to the bus. The messages are sent as
-        #: soon as the bus has finished processing any commands with the same
-        #: command_id and positioner_id.
-        self.command_queue = asyncio.Queue()
+        if not isinstance(channels, (list, tuple)):
+            channels = [channels]
+
+        self.interfaces = []
+        for channel in channels:
+            log.info(f'starting bus with interface {interface_name}, '
+                     f'channel={channel!r}, args={args}, kwargs={kwargs}.')
+            self.interfaces.append(InterfaceClass(channel, *args, **kwargs))
+
+        self._start_notifier()
+
+        self.command_queue = asyncio.Queue(maxsize=100)
         self._command_queue_task = self.loop.create_task(self._process_queue())
 
-        log.debug('started JaegerReaderCallback listener')
+        self.running_commands = collections.defaultdict(dict)
+
+    def _start_notifier(self):
+        """Starts the listener and notifiers."""
+
+        self.listener = JaegerReaderCallback(self._process_reply, loop=self.loop)
+        self.notifier = can.notifier.Notifier(self.interfaces, [self.listener], loop=self.loop)
+
+        log.debug('started JaegerReaderCallback listener and notifiers')
 
     def _process_reply(self, msg):
         """Processes replies from the bus."""
@@ -152,6 +179,25 @@ class JaegerCAN(object):
         can_log.debug(f'({command_id_flag.name!r}, {positioner_id}): queuing reply.')
 
         r_cmd.reply_queue.put_nowait(msg)
+
+    def send_to_interface(self, message, interfaces=None, bus=None):
+        """Sends the message to the appropriate interface and bus."""
+
+        if not self.multichannel and not self.multibus:
+            self.interfaces[0].send(message)
+            return
+
+        # If not interface, send the message to all interfaces.
+        if interfaces is None:
+            interfaces = self.interfaces
+        elif isinstance(interfaces, can.BusABC):
+            interfaces = [interfaces]
+
+        for iface in interfaces:
+            if bus:
+                iface.send(message, bus=bus)
+            else:
+                iface.send(message)
 
     async def _process_queue(self):
         """Processes messages in the command queue."""
@@ -219,7 +265,11 @@ class JaegerCAN(object):
                               f'arbitration_id={message.arbitration_id} '
                               f'and data={data_hex!r}.')
 
-                self.send(message)
+                # Get the interface and bus to which to send the message
+                interfaces = getattr(cmd, '_interface', None)
+                bus = getattr(cmd, '_bus', None)
+
+                self.send_to_interface(message, interfaces=interfaces, bus=bus)
 
     @classmethod
     def from_profile(cls, profile=None, loop=None):
@@ -236,21 +286,35 @@ class JaegerCAN(object):
 
         """
 
-        assert 'interfaces' in config, \
+        assert 'profiles' in config, \
             'configuration file does not have an interfaces section.'
 
         if profile is None:
-            assert 'default' in config['interfaces'], \
+            assert 'default' in config['profiles'], \
                 'default interface not set in configuration.'
-            profile = config['interfaces']['default']
+            profile = config['profiles']['default']
 
-        if profile not in config['interfaces']:
+        if profile not in config['profiles']:
             raise ValueError(f'invalid interface profile {profile}')
 
-        config_data = config['interfaces'][profile].copy()
-        interface = config_data.pop('interface')
+        config_data = config['profiles'][profile].copy()
 
-        return cls.__new__(cls, interface, loop=loop, **config_data)
+        interface = config_data.pop('interface')
+        if interface not in INTERFACES:
+            raise ValueError(f'invalid interface {interface}')
+
+        multichannel = INTERFACES[interface]['multichannel']
+        if multichannel:
+            assert 'channels' in config_data, 'missing configuration argument \'channels\'.'
+            channels = config_data.pop('channels')
+        else:
+            assert 'channel' in config_data, 'missing configuration argument \'channel\'.'
+            channels = [config_data.pop('channel')]
+
+        if interface == 'cannet':
+            return CANnetInterface(interface, channels, loop=loop, **config_data)
+
+        return cls(interface, channels, loop=loop, **config_data)
 
     @staticmethod
     def print_profiles():
@@ -283,3 +347,25 @@ class JaegerCAN(object):
         """Checks whether we can queue the command."""
 
         return not self.is_command_running(command.positioner_id, command.command_id)
+
+
+class CANnetInterface(JaegerCAN):
+    """An interface class specifically for the CAN\@net 200/420 device.
+
+    This class bahaves as `.JaegerCAN` but allows communication with the
+    device itself.
+
+    """
+
+    def _process_reply(self, msg):
+        """Processes a message checking first if it comes from the device."""
+
+        if msg.arbitration_id == 0:
+            return self.handle_device_message(msg)
+
+        super()._process_reply(msg)
+
+    def handle_device_message(self, msg):
+        """Handles a reply from the device (i.e., not from the CAN network)."""
+
+        pass

--- a/python/jaeger/commands/bootloader.py
+++ b/python/jaeger/commands/bootloader.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-05-08 15:20:48
+# @Last modified time: 2019-06-19 13:53:34
 
 import asyncio
 import contextlib
@@ -220,7 +220,7 @@ class GetFirmwareVersion(commands.Command):
         """
 
         def format_version(reply):
-            return '.'.join(format(byt, '02d') for byt in reply.data[0:3])
+            return '.'.join(format(byt, '02d') for byt in reply.data[0:3][::-1])
 
         # If not a broadcast, use the positioner_id of the command
         if self.positioner_id != 0:

--- a/python/jaeger/commands/status.py
+++ b/python/jaeger/commands/status.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-04-27 11:01:02
+# @Last modified time: 2019-06-17 16:27:59
 
 
 import numpy
@@ -25,6 +25,7 @@ class GetID(Command):
 
     command_id = CommandID.GET_ID
     broadcastable = True
+    timeout = 1
 
     def get_ids(self):
         """Returns a list of positioners that replied back."""

--- a/python/jaeger/core/configuration.py
+++ b/python/jaeger/core/configuration.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-05-08 22:11:28
+# @Last modified time: 2019-06-16 16:35:26
 
 import os
 
@@ -90,7 +90,7 @@ def get_config(name, allow_user=True, user_path=None, config_envvar=None,
     else:
         return config
 
-    user_config = yaml.load(open(custom_config_fn))
+    user_config = yaml.load(open(custom_config_fn)) or {}
 
     if merge_mode == 'update':
         return merge_config(user_config, config)

--- a/python/jaeger/etc/jaeger.yml
+++ b/python/jaeger/etc/jaeger.yml
@@ -13,8 +13,14 @@ actor:
         port: 6093
     log_dir: /data/logs/actors/jaeger
 
-interfaces:
-    default: slcan
+profiles:
+    default: cannet
+    cannet:
+        interface: cannet
+        channels: [192.168.0.10]
+        port: 19228
+        buses: [1, 2, 3, 4]
+        bitrate: 1000000
     slcan:
         interface: slcan
         channel: /dev/tty.usbserial-LW3HTDSY

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-18 16:37:41
+# @Last modified time: 2019-06-18 16:57:36
 
 import asyncio
 import os
@@ -214,7 +214,10 @@ class FPS(BaseFPS):
             #: The `.JaegerCAN` instance that serves as a CAN bus interface.
             self.can = can
         else:
-            self.can = JaegerCAN.from_profile(can_profile, loop=loop)
+            try:
+                self.can = JaegerCAN.from_profile(can_profile, loop=loop)
+            except ConnectionRefusedError:
+                raise
 
         super().__init__(layout=layout)
 

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-18 11:29:39
+# @Last modified time: 2019-06-18 12:00:51
 
 import asyncio
 import os
@@ -202,6 +202,9 @@ class FPS(BaseFPS):
 
         self.loop = loop or asyncio.get_event_loop()
 
+        #: dict: The mapping between positioners and buses.
+        self.positioner_to_bus = {}
+
         if isinstance(can, JaegerCAN):
             #: The `.JaegerCAN` instance that serves as a CAN bus interface.
             self.can = can
@@ -216,8 +219,6 @@ class FPS(BaseFPS):
         Only relevant if the bus interface is multichannel/multibus.
 
         """
-
-        self.positioner_to_bus = {}
 
         if len(self.can.interfaces) == 1 and not self.can.multibus:
             self._is_multibus = False

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-17 22:06:30
+# @Last modified time: 2019-06-18 11:29:39
 
 import asyncio
 import os
@@ -219,7 +219,7 @@ class FPS(BaseFPS):
 
         self.positioner_to_bus = {}
 
-        if not self.can.multichannel and not self.can.multibus:
+        if len(self.can.interfaces) == 1 and not self.can.multibus:
             self._is_multibus = False
             return
 

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-18 12:00:51
+# @Last modified time: 2019-06-18 16:37:41
 
 import asyncio
 import os
@@ -159,6 +159,11 @@ class BaseFPS(object):
             status[positioner.positioner_id] = {'position': [pos_alpha, pos_beta],
                                                 'status': pos_status,
                                                 'firmware': pos_firmware}
+
+        try:
+            status['devices'] = self.can.device_status
+        except AttributeError:
+            pass
 
         return status
 

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-05-22 18:10:31
+# @Last modified time: 2019-06-17 16:52:51
 
 import asyncio
 import os
@@ -168,7 +168,7 @@ class FPS(BaseFPS):
 
     Parameters
     ----------
-    bus : `.JaegerCAN` instance
+    can : `.JaegerCAN` instance
         The CAN bus to use.
     layout : str
         The layout describing the position of the robots on the focal plane.
@@ -198,19 +198,44 @@ class FPS(BaseFPS):
 
     """
 
-    def __init__(self, bus=None, layout=None, can_profile=None, loop=None):
+    def __init__(self, can=None, layout=None, can_profile=None, loop=None):
 
         self.loop = loop or asyncio.get_event_loop()
 
-        if isinstance(bus, JaegerCAN):
+        if isinstance(can, JaegerCAN):
             #: The `.JaegerCAN` instance that serves as a CAN bus interface.
-            self.bus = bus
+            self.can = can
         else:
-            self.bus = JaegerCAN.from_profile(can_profile, loop=loop)
+            self.can = JaegerCAN.from_profile(can_profile, loop=loop)
 
         super().__init__(layout=layout)
 
-    def send_command(self, command_id, positioner_id=0, data=[], **kwargs):
+    async def _get_positioner_bus_map(self):
+        """Creates the positioner-to-bus map.
+
+        Only relevant if the bus interface is multichannel/multibus.
+
+        """
+
+        self.positioner_to_bus = {}
+
+        if not self.can.multichannel and not self.can.multibus:
+            self._is_multibus = False
+            return
+
+        self._is_multibus = True
+
+        id_cmd = self.send_command(CommandID.GET_ID, broadcast=True)
+        await id_cmd
+
+        # Parse the replies
+        for reply in id_cmd.replies:
+            self.positioner_to_bus[reply.positioner_id] = (reply.message.interface,
+                                                           reply.message.bus)
+
+    def send_command(self, command_id, positioner_id=0, data=[],
+                     interface=None, bus=None, broadcast=False,
+                     silent_on_conflict=False, override=False, **kwargs):
         """Sends a command to the bus.
 
         Parameters
@@ -222,6 +247,26 @@ class FPS(BaseFPS):
             The positioner ID to command, or zero for broadcast.
         data : bytearray
             The bytes to send.
+        interface : int
+            The index in the interface list for the interface to use. Only
+            relevant in case of a multibus interface. If `None`, the positioner
+            to bus map will be used.
+        bus : int
+            The bus within the interface to be used. Only relevant in case of
+            a multibus interface. If `None`, the positioner to bus map will
+            be used.
+        broadcast : bool
+            If `True`, sends the command to all the buses.
+        silent_on_conflict : bool
+            If set, does not issue a warning if at the time of queuing this
+            command there is already a command for the same positioner id
+            running. This is useful for example for poller when we change the
+            delay and the previous command is still running. In those cases
+            this option avoids annoying messages.
+        override : bool
+            If another instance of this command_id with the same positioner_id
+            is running, cancels it and schedules this one immediately.
+            Otherwise the command is queued until the first one finishes.
         kwargs : dict
             Extra arguments to be passed to the command.
 
@@ -230,19 +275,54 @@ class FPS(BaseFPS):
         command_flag = CommandID(command_id)
         CommandClass = command_flag.get_command()
 
-        silent_on_conflict = kwargs.pop('silent_on_conflict', False)
-
         command = CommandClass(positioner_id=positioner_id,
-                               bus=self.bus, loop=self.loop,
-                               data=data, **kwargs)
+                               loop=self.loop, data=data, **kwargs)
 
-        if not command.send(silent_on_conflict=silent_on_conflict):
+        command_id = command.command_id
+        command_name = command.name
+
+        if command.status.is_done:
+            log.error(f'{command_name, positioner_id}: trying to send a done command.')
             return False
+
+        command._override = override
+        command._silent_on_conflict = silent_on_conflict
+
+        # By default a command will be sent to all interfaces and buses.
+        # Normally we want to set the interface and bus to which the command
+        # will be sent.
+        if not broadcast:
+            self.set_interface(command, bus=bus, interface=interface)
+
+        self.can.command_queue.put_nowait(command)
+        log.debug(f'{command_name, positioner_id}: added command to CAN processing queue.')
 
         return command
 
+    def set_interface(self, command, interface=None, bus=None):
+        """Sets the interface and bus to which to send a command."""
+
+        # Don't do anything if the interface is not multibus
+        if not self._is_multibus or command.positioner_id == 0:
+            return
+
+        if bus or interface:
+            command._interface = interface
+            command._bus = bus
+            return
+
+        interface, bus = self.positioner_to_bus[command.positioner_id]
+
+        command._interface = interface
+        command._bus = bus
+
+        return
+
     async def initialise(self, layout=None, check_positioners=True):
         """Initialises all positioners with status and firmware version."""
+
+        # Get the positioner-to-bus map
+        await self._get_positioner_bus_map()
 
         # Resets all positioner
         for positioner in self.positioners.values():

--- a/python/jaeger/interfaces/__init__.py
+++ b/python/jaeger/interfaces/__init__.py
@@ -1,0 +1,4 @@
+
+# flake8: noqa
+
+from .cannet import CANNetBus

--- a/python/jaeger/interfaces/cannet.py
+++ b/python/jaeger/interfaces/cannet.py
@@ -6,7 +6,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-17 17:24:17
+# @Last modified time: 2019-06-18 11:41:39
 
 import socket
 import time
@@ -15,7 +15,7 @@ from can import BusABC, Message
 
 
 class CANNetBus(BusABC):
-    """Interface for Ixxat CAN@net NT 200/420.
+    """Interface for Ixxat CAN\@net NT 200/420.
 
     Parameters
     ----------

--- a/python/jaeger/interfaces/cannet.py
+++ b/python/jaeger/interfaces/cannet.py
@@ -6,7 +6,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-17 16:12:00
+# @Last modified time: 2019-06-17 17:23:54
 
 import socket
 import time
@@ -146,7 +146,7 @@ class CANNetBus(BusABC):
                           dlc=0,
                           data=msgStr)
             msg.bus = None
-            msg.interface = None
+            msg.interface = self
             return msg, False
 
         # check if it is the proper CAN bus

--- a/python/jaeger/interfaces/cannet.py
+++ b/python/jaeger/interfaces/cannet.py
@@ -6,7 +6,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-17 17:23:54
+# @Last modified time: 2019-06-17 17:24:17
 
 import socket
 import time
@@ -137,7 +137,7 @@ class CANNetBus(BusABC):
             return None, False
 
         # Message is M 1 CSD 100 55 AA 55 AA or M 2 CED 18FE0201 01 02 03 04 05 06 07 08
-        # Check if we have a message from the CAN network. Otherwise this is a messahe
+        # Check if we have a message from the CAN network. Otherwise this is a message
         # from the device so we return it.
         data = readStr.split(' ')
         if data[0] != 'M':

--- a/python/jaeger/interfaces/cannet.py
+++ b/python/jaeger/interfaces/cannet.py
@@ -6,7 +6,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-18 11:41:39
+# @Last modified time: 2019-06-18 15:04:13
 
 import socket
 import time
@@ -145,8 +145,8 @@ class CANNetBus(BusABC):
                           timestamp=time.time(),
                           dlc=0,
                           data=msgStr)
-            msg.bus = None
             msg.interface = self
+            msg.bus = None
             return msg, False
 
         # check if it is the proper CAN bus
@@ -188,8 +188,8 @@ class CANNetBus(BusABC):
                           is_remote_frame=remote,
                           dlc=dlc,
                           data=frame)
-            msg.bus = bus
             msg.interface = self
+            msg.bus = bus
             return msg, False
 
         return None, False

--- a/python/jaeger/positioner.py
+++ b/python/jaeger/positioner.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-05-22 21:06:42
+# @Last modified time: 2019-06-18 15:06:38
 
 import asyncio
 import warnings
@@ -74,11 +74,11 @@ class Positioner(StatusMixIn):
 
         if poller == 'status' or poller == 'all':
             if not self.status_poller.running:
-                await self.status_poller.start()
+                self.status_poller.start()
 
         if poller == 'position' or poller == 'all':
             if not self.position_poller.running:
-                await self.position_poller.start()
+                self.position_poller.start()
 
     async def stop_pollers(self, poller='all'):
         """Stops the status and position pollers.

--- a/python/jaeger/utils/helpers.py
+++ b/python/jaeger/utils/helpers.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-17 21:34:04
+# @Last modified time: 2019-06-18 15:06:19
 
 import asyncio
 from concurrent.futures import Executor
@@ -197,9 +197,9 @@ class Poller(object):
             original delay."""
 
         await self.stop()
-        await self.start(delay)
+        self.start(delay)
 
-    async def start(self, delay=None):
+    def start(self, delay=None):
         """Starts the poller.
 
         Parameters

--- a/python/jaeger/utils/helpers.py
+++ b/python/jaeger/utils/helpers.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-06-18 15:06:19
+# @Last modified time: 2019-06-18 16:42:01
 
 import asyncio
 from concurrent.futures import Executor
@@ -215,6 +215,8 @@ class Poller(object):
 
         self.delay = delay or self._orig_delay
         self._task = asyncio.create_task(self.poller())
+
+        return self
 
     async def stop(self):
         """Cancel the poller."""

--- a/python/jaeger/utils/helpers.py
+++ b/python/jaeger/utils/helpers.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2019-05-23 08:52:38
+# @Last modified time: 2019-06-17 21:34:04
 
 import asyncio
 from concurrent.futures import Executor
@@ -240,7 +240,7 @@ class Poller(object):
 class AsyncioExecutor(Executor):
     """An executor to run coroutines from a normal function.
 
-    Copied from `http://bit.ly/2IYmqzN`__.
+    Copied from http://bit.ly/2IYmqzN.
 
     To use, do ::
 


### PR DESCRIPTION
For #7 and #9.
Fixes #11.

Right now the mapping between positioner and bus is done automatically by broadcasting a `GET_ID` to all the possible devices and buses. This is probably ok but we may need to implement the mapping as a file or a database entry.