### PR TITLE
Reworked UID handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Changelog
 * Update `.PositionerStatus` maskbits.
 * Significant clean-up of how pollers are used.
 * `~jaeger.commands.send_trajectory` now raises exceptions on error.
+* :feature:`57` Added `.FPS.moving` and `.Positioner.moving` attributes to determine whether it is save to move the FPS.
+* :feature:`56` Move time for go to moves is calculated and reported.
+* Very significant rewrite of how messages and replies are matched. Now there is a pool of unique identifiers. Each message gets assigned a UID from the pool corresponding to its ``command_id`` and ``positioner_id``. When a reply is received, it is matched based on ``command_id``, ``positioner_id``, and ``UID``. At that point the UID is returned to the pool. Broadcast messages always receive the reserved ``UID=0``. This means that two broadcast of the same command should not be running at the same time or replies could be misassigned.
 
 * :release:`0.4.0 <2019-11-19>`
 * :feature:`46` Implement a QA database for moves.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 =========
 
 * Update `.PositionerStatus` maskbits.
+* Significant clean-up of how pollers are used.
+* `~jaeger.commands.send_trajectory` now raises exceptions on error.
 
 * :release:`0.4.0 <2019-11-19>`
 * :feature:`46` Implement a QA database for moves.

--- a/python/jaeger/actor/actor.py
+++ b/python/jaeger/actor/actor.py
@@ -35,7 +35,7 @@ class JaegerActor(clu.LegacyActor):
         # Add ActorHandler to log
         self.actor_handler = ActorHandler(self)
         log.addHandler(self.actor_handler)
-        self.actor_handler.setLevel(logging.ERROR)
+        self.actor_handler.setLevel(logging.INFO)
 
         # if fps.wago and fps.wago.connected:
         #     self.timer_commands.add_command('wago status', delay=60)

--- a/python/jaeger/actor/commands/positioner.py
+++ b/python/jaeger/actor/commands/positioner.py
@@ -78,7 +78,7 @@ async def goto(command, fps, positioner_id, alpha, beta, speed, all, force):
 @click.option('-a', '--all', is_flag=True, default=False,
               help='applies to all valid positioners.')
 async def speed(command, fps, positioner_id, alpha, beta, all):
-    """Sets the ``(alpha, beta)`` speed in RPM on the output."""
+    """Sets the ``(alpha, beta)`` speed in RPM on the input."""
 
     if all:
         positioner_id = list(fps.positioners.keys())

--- a/python/jaeger/actor/commands/positioner.py
+++ b/python/jaeger/actor/commands/positioner.py
@@ -83,7 +83,7 @@ async def goto(command, fps, positioner_id, alpha, beta, speed, all, force, rela
 
         tasks.append(fps.positioners[pid].goto(alpha, beta, speed=speed, relative=relative))
 
-    command.info(move_time=max_time)
+    command.info(move_time=round(max_time, 2))
 
     result = await clu.as_complete_failer(tasks, on_fail_callback=fps.abort_trajectory)
 

--- a/python/jaeger/can.py
+++ b/python/jaeger/can.py
@@ -187,13 +187,17 @@ class JaegerCAN(object):
             return
 
         command_id_flag = CommandID(command_id)
-        self.running_commands = [rcmd for rcmd in self.running_commands if not rcmd.status.is_done]
+        self.running_commands = [rcmd for rcmd in self.running_commands
+                                 if not rcmd.status.is_done]
 
         found = False
         for r_cmd in self.running_commands:
-            if r_cmd.command_id == command_id and reply_uid in r_cmd.message_uids:
-                found = True
-                break
+            if r_cmd.command_id == command_id:
+                if ((reply_uid == 0 and r_cmd.positioner_id == 0) or
+                        (reply_uid in r_cmd.message_uids and
+                         positioner_id == r_cmd.positioner_id)):
+                    found = True
+                    break
 
         if found:
             can_log.debug(f'({command_id_flag.name}, '

--- a/python/jaeger/can.py
+++ b/python/jaeger/can.py
@@ -177,7 +177,7 @@ class JaegerCAN(object):
 
             # Now lock the FPS.
             if self.fps:
-                self.loop.create_task(self.fps.lock(abort_trajectories=False))
+                self.loop.create_task(self.fps.lock(abort_trajectories=True))
 
         if command_id == 0:
             can_log.warning('invalid command with command_id=0, '

--- a/python/jaeger/can.py
+++ b/python/jaeger/can.py
@@ -232,7 +232,7 @@ class JaegerCAN(object):
             data_hex = binascii.hexlify(message.data).decode()
             can_log.debug(log_header + 'sending message with '
                           f'arbitration_id={message.arbitration_id}, '
-                          f'UID={message.uid} '
+                          f'UID={message.uid}, '
                           f'and data={data_hex!r} to '
                           f'interface {iface_idx}, '
                           f'bus={0 if not bus else bus!r}.')

--- a/python/jaeger/commands/__init__.py
+++ b/python/jaeger/commands/__init__.py
@@ -79,7 +79,10 @@ from .trajectory import *
 _tmp_command_list = []
 
 for item in vars().copy().values():
-    if hasattr(item, '__bases__') and Command in item.__bases__:
+    if not hasattr(item, '__bases__'):
+        continue
+    bases = item.__bases__
+    if  Command in bases or any([issubclass(base, Command) for base in bases]):
         _tmp_command_list.append((item.command_id, item))
 
 COMMAND_LIST = dict(sorted(_tmp_command_list))

--- a/python/jaeger/commands/base.py
+++ b/python/jaeger/commands/base.py
@@ -230,7 +230,7 @@ class Command(StatusMixIn, asyncio.Future):
         self.message_uids = []
 
         if self.command_id not in UID_POOL:
-            UID_POOL[self.command_id] = set(range(config['positioner']['uid_bits']))
+            UID_POOL[self.command_id] = set(range(2**config['positioner']['uid_bits']))
 
         if n_positioners is not None:
             assert self.is_broadcast, 'n_positioners can only be used with a broadcast.'

--- a/python/jaeger/commands/base.py
+++ b/python/jaeger/commands/base.py
@@ -58,7 +58,7 @@ class Message(can.Message):
         self.uid = uid
 
         uid_bits = config['positioner']['uid_bits']
-        max_uid = 2**uid_bits - 1
+        max_uid = 2**uid_bits
         assert self.uid < max_uid, f'UID must be <= {max_uid}.'
 
         if extended_id:

--- a/python/jaeger/commands/base.py
+++ b/python/jaeger/commands/base.py
@@ -189,6 +189,8 @@ class Command(StatusMixIn, asyncio.Future):
     timeout = 5
     #: Whether it's safe to execute this command when the FPS is locked.
     safe = False
+    #: Whether this command produces a positioner move.
+    move_command = False
 
     def __init__(self, positioner_id, loop=None, timeout=None,
                  done_callback=None, n_positioners=None, data=None):

--- a/python/jaeger/commands/base.py
+++ b/python/jaeger/commands/base.py
@@ -10,6 +10,7 @@ import asyncio
 import binascii
 import collections
 import logging
+import time
 
 import can
 
@@ -233,6 +234,9 @@ class Command(StatusMixIn, asyncio.Future):
         # Generate a UUID for this command.
         self.command_uid = COMMAND_UID
         COMMAND_UID += 1
+
+        # Starting time
+        self.start_time = time.time()
 
         # Stores the UIDs of the messages sent for them to be compared with
         # the replies.

--- a/python/jaeger/commands/goto.py
+++ b/python/jaeger/commands/goto.py
@@ -21,6 +21,7 @@ class InitialiseDatums(Command):
 
     command_id = CommandID.INITIALIZE_DATUMS
     broadcastable = False
+    move_command = True
 
 
 class GotoAbsolutePosition(Command):
@@ -28,6 +29,7 @@ class GotoAbsolutePosition(Command):
 
     command_id = CommandID.GO_TO_ABSOLUTE_POSITION
     broadcastable = False
+    move_command = True
 
     def __init__(self, alpha=0.0, beta=0.0, **kwargs):
 
@@ -64,6 +66,7 @@ class GotoRelativePosition(GotoAbsolutePosition):
 
     command_id = CommandID.GO_TO_RELATIVE_POSITION
     broadcastable = False
+    move_command = True
 
 
 class SetActualPosition(Command):
@@ -72,6 +75,8 @@ class SetActualPosition(Command):
     command_id = CommandID.SET_ACTUAL_POSITION
     broadcastable = False
     safe = True
+    move_command = True     # Technically not a move command but we don't
+                            # want to issue it during a move.
 
     def __init__(self, alpha=0.0, beta=0.0, **kwargs):
 
@@ -90,6 +95,7 @@ class SetSpeed(Command):
     command_id = CommandID.SET_SPEED
     broadcastable = False
     safe = True
+    move_command = True
 
     def __init__(self, alpha=0, beta=0, **kwargs):
 
@@ -106,6 +112,8 @@ class SetCurrent(Command):
 
     command_id = CommandID.SET_CURRENT
     broadcastable = False
+    safe = True
+    move_command = True
 
     def __init__(self, alpha=0, beta=0, **kwargs):
 

--- a/python/jaeger/commands/trajectory.py
+++ b/python/jaeger/commands/trajectory.py
@@ -24,7 +24,7 @@ __ALL__ = ['send_trajectory', 'SendNewTrajectory', 'SendTrajectoryData',
            'StartTrajectory', 'StopTrajectory']
 
 
-async def send_trajectory(fps, trajectories, kaiju_check=True):
+async def send_trajectory(fps, trajectories):
     """Sends a set of trajectories to the positioners.
 
     .. danger:: This method can cause the positioners to collide if it is
@@ -41,8 +41,6 @@ async def send_trajectory(fps, trajectories, kaiju_check=True):
         dictionary containing two keys: ``alpha`` and ``beta``, each
         pointing to a list of tuples ``(position, time)``, where
         ``position`` is in degrees and ``time`` is in seconds.
-    kaiju_check : `bool`
-        Whether to check the trajectories with kaiju before sending it.
 
     Examples
     --------

--- a/python/jaeger/commands/trajectory.py
+++ b/python/jaeger/commands/trajectory.py
@@ -66,6 +66,9 @@ async def send_trajectory(fps, trajectories):
     if fps.locked:
         raise FPSLockedError('FPS is locked. Cannot send trajectories.')
 
+    if fps.moving:
+        raise TrajectoryError('the FPS is moving. Cannot send new trajectory.')
+
     PosStatus = maskbits.PositionerStatus
 
     if isinstance(trajectories, (str, pathlib.Path)):

--- a/python/jaeger/commands/trajectory.py
+++ b/python/jaeger/commands/trajectory.py
@@ -8,14 +8,13 @@
 
 import asyncio
 import pathlib
-import warnings
 
 import numpy
 from ruamel.yaml import YAML
 
 from jaeger import config, log, maskbits
 from jaeger.commands import MOTOR_STEPS, TIME_STEP, Command, CommandID
-from jaeger.core.exceptions import FPSLockedError, JaegerUserWarning
+from jaeger.core.exceptions import FPSLockedError, TrajectoryError
 from jaeger.utils import int_to_bytes
 
 
@@ -27,8 +26,8 @@ __ALL__ = ['send_trajectory', 'SendNewTrajectory', 'SendTrajectoryData',
 async def send_trajectory(fps, trajectories):
     """Sends a set of trajectories to the positioners.
 
-    .. danger:: This method can cause the positioners to collide if it is
-        commanded with ``kaiju_check=False``.
+    This is a low-level function that raises errors when a problem is
+    encountered. Most users should use `.FPS.send_trajectory` instead.
 
     Parameters
     ----------
@@ -41,6 +40,13 @@ async def send_trajectory(fps, trajectories):
         dictionary containing two keys: ``alpha`` and ``beta``, each
         pointing to a list of tuples ``(position, time)``, where
         ``position`` is in degrees and ``time`` is in seconds.
+
+    Raises
+    ------
+    TrajectoryError
+        If encounters a problem sending the trajectory.
+    FPSLockedError
+        If the FPS is locked.
 
     Examples
     --------
@@ -55,6 +61,8 @@ async def send_trajectory(fps, trajectories):
 
     """
 
+    log.info('starting trajectory ...')
+
     if fps.locked:
         raise FPSLockedError('FPS is locked. Cannot send trajectories.')
 
@@ -66,25 +74,10 @@ async def send_trajectory(fps, trajectories):
     elif isinstance(trajectories, dict):
         pass
     else:
-        raise ValueError('invalid trajectory data.')
+        raise TrajectoryError('invalid trajectory data.')
 
-    if kaiju_check:
-        # TODO: implement call to kaiju
-        pass
-    else:
-        warnings.warn('about to send a trajectory that has not been checked '
-                      'by kaiju. This will end up in tears.', JaegerUserWarning)
-
-    log.info('stopping the pollers before sending the trajectory.')
-    await fps.pollers.stop()
-
-    await asyncio.sleep(1)
-
-    try:
-        await fps.update_status(positioner_id=list(trajectories.keys()), timeout=1.)
-    except KeyError as ee:
-        log.error(f'some positioners in the trajectory are not connected: {ee}')
-        return False
+    if not await fps.update_status(positioner_id=list(trajectories.keys()), timeout=1.):
+        raise TrajectoryError(f'some positioners did not respond.')
 
     n_points = {}
     max_time = 0.0
@@ -98,8 +91,8 @@ async def send_trajectory(fps, trajectories):
         if (PosStatus.DATUM_ALPHA_INITIALIZED not in status or
                 PosStatus.DATUM_BETA_INITIALIZED not in status or
                 PosStatus.DISPLACEMENT_COMPLETED not in status):
-            log.error(f'positioner_id={pos_id} is not ready to receive a trajectory.')
-            return False
+            raise TrajectoryError(f'positioner_id={pos_id} is not '
+                                  'ready to receive a trajectory.')
 
         traj_pos = trajectories[pos_id]
 
@@ -152,45 +145,34 @@ async def send_trajectory(fps, trajectories):
 
             for cmd in data_cmds:
                 if cmd.status.failed:
-                    log.error('at least one SEND_TRAJECTORY_COMMAND failed. Aborting.')
-                    return False
+                    raise TrajectoryError('at least one SEND_TRAJECTORY_COMMAND failed.')
 
     # Finalise the trajectories
     end_traj_cmds = await fps.send_to_all('TRAJECTORY_DATA_END',
                                           positioners=list(trajectories.keys()))
 
-    failed = False
     for cmd in end_traj_cmds:
 
         if cmd.status.failed:
-            await fps.abort_trajectory(trajectories.keys())
-            failed = True
-            break
+            raise TrajectoryError('TRAJECTORY_DATA_END failed.')
 
         if maskbits.ResponseCode.INVALID_TRAJECTORY in cmd.replies[0].response_code:
-            log.error(f'positioner_id={cmd.positioner_id} got an '
-                      f'INVALID_TRAJECTORY reply. Aborting trajectory.')
-            await fps.abort_trajectory(trajectories.keys())
-            failed = True
-            break
-
-    if failed:
-        log.info('restarting the pollers.')
-        fps.pollers.start()
-        return False
+            raise TrajectoryError(f'positioner_id={cmd.positioner_id} got an '
+                                  f'INVALID_TRAJECTORY reply.')
 
     # Prepare to start the trajectories. Make position polling faster and
     # output expected time.
     log.info(f'expected time to complete trajectory: {max_time:.2f} seconds.')
 
-    log.info('restarting the pollers.')
-    fps.pollers.start()
-
-    await fps.pollers.position.set_delay(0.5)
-
     # Start trajectories
-    await fps.send_command('START_TRAJECTORY', positioner_id=0, timeout=1,
-                           n_positioners=len(trajectories))
+    command = await fps.send_command('START_TRAJECTORY', positioner_id=0, timeout=1,
+                                     n_positioners=len(trajectories))
+
+    if command.status.failed:
+        await fps.abort_trajectory()
+        raise TrajectoryError('START_TRAJECTORY failed')
+
+    await fps.pollers.set_delay(1)
 
     # Wait approximate time before starting to poll for status
     await asyncio.sleep(0.95 * max_time, loop=fps.loop)
@@ -206,8 +188,8 @@ async def send_trajectory(fps, trajectories):
     results = await asyncio.gather(*wait_status, loop=fps.loop)
 
     if not all(results):
-        log.error('some positioners did not complete the move.')
-        return False
+        await fps.pollers.set_delay()
+        raise TrajectoryError('some positioners did not complete the move.')
 
     log.info('all positioners have reached their final positions.')
 
@@ -222,6 +204,7 @@ class SendNewTrajectory(Command):
 
     command_id = CommandID.SEND_NEW_TRAJECTORY
     broadcastable = False
+    move_command = True
 
     def __init__(self, n_alpha, n_beta, **kwargs):
 
@@ -255,6 +238,7 @@ class SendTrajectoryData(Command):
 
     command_id = CommandID.SEND_TRAJECTORY_DATA
     broadcastable = False
+    move_command = True
 
     def __init__(self, positions, **kwargs):
 
@@ -279,6 +263,7 @@ class TrajectoryDataEnd(Command):
 
     command_id = CommandID.TRAJECTORY_DATA_END
     broadcastable = False
+    move_command = True
 
 
 class TrajectoryTransmissionAbort(Command):
@@ -286,6 +271,7 @@ class TrajectoryTransmissionAbort(Command):
 
     command_id = CommandID.TRAJECTORY_TRANSMISSION_ABORT
     broadcastable = False
+    move_command = True
 
 
 class StartTrajectory(Command):
@@ -293,6 +279,7 @@ class StartTrajectory(Command):
 
     command_id = CommandID.START_TRAJECTORY
     broadcastable = True
+    move_command = True
 
 
 class StopTrajectory(Command):

--- a/python/jaeger/commands/trajectory.py
+++ b/python/jaeger/commands/trajectory.py
@@ -167,6 +167,9 @@ async def send_trajectory(fps, trajectories):
     # output expected time.
     log.info(f'expected time to complete trajectory: {max_time:.2f} seconds.')
 
+    for positioner_id in list(trajectories.keys()):
+        fps[positioner_id].move_time = max_time
+
     # Start trajectories
     command = await fps.send_command('START_TRAJECTORY', positioner_id=0, timeout=1,
                                      n_positioners=len(trajectories))

--- a/python/jaeger/core/exceptions.py
+++ b/python/jaeger/core/exceptions.py
@@ -5,7 +5,7 @@
 #
 # @Author: Brian Cherinka
 # @Date:   2017-12-05 12:01:21
-# @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Last modified by: José Sánchez-Gallego
 # @Last Modified time: 2017-12-05 12:19:32
 
 
@@ -56,8 +56,14 @@ class JaegerMissingDependency(JaegerError):
     pass
 
 
+class TrajectoryError(JaegerError):
+    """A trajectory error."""
+    pass
+
+
 class JaegerWarning(Warning):
     """Base warning for Jaeger."""
+    pass
 
 
 class JaegerUserWarning(UserWarning, JaegerWarning):

--- a/python/jaeger/etc/jaeger.yml
+++ b/python/jaeger/etc/jaeger.yml
@@ -40,6 +40,7 @@ fps:
 positioner:
     motor_speed: 3000
     initialise_datums_timeout: 300
+    reduction_ratio: 1024
     uid_bits: 6  # Number of bits available for the Message UID.
     trajectory_data_n_points: 3  # How many points from the trajectory
                                  # are we putting in each SEND_TRAJECTORY_DATA command.

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -550,7 +550,7 @@ class FPS(BaseFPS):
 
         if self.locked:
             log.info('FPS is locked. Trying to unlock it.')
-            if not self.unlock():
+            if not await self.unlock():
                 log.error('FPS cannot be unlocked. Initialisation failed.')
                 return False
             else:

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -373,7 +373,7 @@ class FPS(BaseFPS):
 
         if command.status.is_done:
             log.error(f'{command_name, positioner_id}: trying to send a done command.')
-            return False
+            return command
 
         command._override = override
         command._silent_on_conflict = silent_on_conflict

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -453,6 +453,12 @@ class FPS(BaseFPS):
 
         return True
 
+    @property
+    def moving(self):
+        """Returns `True` if any of the positioners is moving."""
+
+        return any([pos.moving for pos in self.positioners.values()])
+
     async def initialise(self, allow_unknown=True):
         """Initialises all positioners with status and firmware version.
 

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -16,7 +16,7 @@ import astropy.table
 from jaeger import config, log, maskbits
 from jaeger.can import JaegerCAN
 from jaeger.commands import Command, CommandID, send_trajectory
-from jaeger.core.exceptions import FPSLockedError, JaegerUserWarning
+from jaeger.core.exceptions import FPSLockedError, JaegerUserWarning, TrajectoryError
 from jaeger.positioner import Positioner
 from jaeger.utils import Poller, PollerList, bytes_to_int, get_qa_database
 from jaeger.wago import WAGO
@@ -708,7 +708,11 @@ class FPS(BaseFPS):
 
         """
 
-        return await send_trajectory(self, *args, **kwargs)
+        try:
+            return await send_trajectory(self, *args, **kwargs)
+        except TrajectoryError as ee:
+            log.error(f'sending trajectory failed with error: {ee}')
+            return False
 
     def abort(self):
         """Aborts trajectories and stops positioners."""

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -365,6 +365,12 @@ class FPS(BaseFPS):
                 raise FPSLockedError('solve the problem and unlock the FPS '
                                      'before sending commands.')
 
+        elif self.moving and command.move_command:
+            command.cancel(silent=True)
+            log.error('cannot send move command while the FPS is moving. '
+                      'Use FPS.abort_trajectory() to stop the FPS.')
+            return command
+
         if command.status.is_done:
             log.error(f'{command_name, positioner_id}: trying to send a done command.')
             return False

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -437,8 +437,10 @@ class FPS(BaseFPS):
         if abort_trajectories:
             await self.abort_trajectory()
 
-    def unlock(self, force=False):
+    async def unlock(self, force=False):
         """Unlocks the `.FPS` if all collisions have been resolved."""
+
+        await self.update_status(timeout=0.1)
 
         for positioner in self.positioners.values():
             if positioner.collision:

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -6,8 +6,8 @@
 # @Filename: fps.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 
-import os
 import asyncio
+import os
 import pathlib
 import warnings
 

--- a/python/jaeger/maskbits.py
+++ b/python/jaeger/maskbits.py
@@ -66,7 +66,7 @@ class CommandStatus(Maskbit):
     def timed_out(self):
         """Returns True if the command timed out."""
 
-        return True if self.TIMEDOUT else False
+        return True if self.TIMEDOUT in self else False
 
 
 class PositionerStatus(Maskbit):

--- a/python/jaeger/maskbits.py
+++ b/python/jaeger/maskbits.py
@@ -132,7 +132,7 @@ class BootloaderStatus(Maskbit):
     UNKNOWN = 0x40000000
 
 
-class ResponseCode(enum.IntFlag):
+class ResponseCode(enum.Flag):
     """Maskbit for the status of the bootloader."""
 
     COMMAND_ACCEPTED = 0

--- a/python/jaeger/positioner.py
+++ b/python/jaeger/positioner.py
@@ -276,8 +276,6 @@ class Positioner(StatusMixIn):
                           'trajectories during initialisation.', JaegerUserWarning)
             return False
 
-        result = await self.fps.send_command('TRAJECTORY_TRANSMISSION_ABORT',
-                                             positioner_id=self.positioner_id)
         if not result:
             log.error(f'positioner {self.positioner_id}: failed aborting '
                       'trajectory transmission during initialisation.')

--- a/python/jaeger/positioner.py
+++ b/python/jaeger/positioner.py
@@ -73,8 +73,7 @@ class Positioner(StatusMixIn):
     def moving(self):
         """Returns `True` if the positioner is moving."""
 
-        if (self.status.DISPLACEMENT_COMPLETED not in self.status or
-                self.status.RECEIVING_TRAJECTORY in self.status):
+        if self.status.DISPLACEMENT_COMPLETED not in self.status:
             return True
 
         return False
@@ -165,7 +164,7 @@ class Positioner(StatusMixIn):
 
             await command
 
-            if command.status.failed:
+            if command.status.failed or command.status.timed_out:
                 log.error(f'positioner {self.positioner_id}: '
                           f'{CommandID.GET_STATUS.name!r} failed to complete.')
                 return False

--- a/python/jaeger/positioner.py
+++ b/python/jaeger/positioner.py
@@ -374,9 +374,9 @@ class Positioner(StatusMixIn):
         Parameters
         ----------
         alpha : float
-            The speed of the alpha arm, in RPM on the output.
+            The speed of the alpha arm, in RPM on the input.
         beta : float
-            The speed of the beta arm, in RPM on the output.
+            The speed of the beta arm, in RPM on the input.
         force : bool
             Allows to set speed limits outside the normal range.
 
@@ -433,7 +433,7 @@ class Positioner(StatusMixIn):
         beta : float
             The position where to move the beta arm, in degrees.
         speed : tuple
-            The speed of the ``(alpha, beta)`` arms, in RPM on the output.
+            The speed of the ``(alpha, beta)`` arms, in RPM on the input.
         relative : bool
             Whether the movement is absolute or relative to the current
             position.

--- a/python/jaeger/positioner.py
+++ b/python/jaeger/positioner.py
@@ -477,7 +477,7 @@ class Positioner(StatusMixIn):
 
         # Set the speed
         original_speed = self.speed[:]
-        if speed and not await self.set_speed(*speed, force=force):
+        if speed and all(speed) and not await self.set_speed(*speed, force=force):
             return False
 
         # Go to position

--- a/python/jaeger/positioner.py
+++ b/python/jaeger/positioner.py
@@ -72,7 +72,7 @@ class Positioner(StatusMixIn):
     @property
     def moving(self):
         """Returns `True` if the positioner is moving."""
-        return False
+
         if (self.status.DISPLACEMENT_COMPLETED not in self.status or
                 self.status.RECEIVING_TRAJECTORY in self.status):
             return True

--- a/python/jaeger/positioner.py
+++ b/python/jaeger/positioner.py
@@ -298,8 +298,8 @@ class Positioner(StatusMixIn):
             return False
 
         # Sets the default speed
-        if not await self._set_speed(alpha=_pos_conf['motor_speed'],
-                                     beta=_pos_conf['motor_speed']):
+        if not await self.set_speed(alpha=_pos_conf['motor_speed'],
+                                    beta=_pos_conf['motor_speed']):
             return False
 
         log.debug(f'positioner {self.positioner_id}: initialisation complete.')
@@ -368,14 +368,35 @@ class Positioner(StatusMixIn):
 
         return set_position_command
 
-    async def _set_speed(self, alpha, beta):
-        """Sets motor speeds."""
+    async def set_speed(self, alpha, beta, force=False):
+        """Sets motor speeds.
+
+        Parameters
+        ----------
+        alpha : float
+            The speed of the alpha arm, in RPM on the output.
+        beta : float
+            The speed of the beta arm, in RPM on the output.
+        force : bool
+            Allows to set speed limits outside the normal range.
+
+        """
+
+        MIN_SPEED = 0
+        MAX_SPEED = 5000
+
+        if (alpha < MIN_SPEED or alpha > MAX_SPEED or
+                beta < MIN_SPEED or beta > MAX_SPEED) and not force:
+            log.error(f'positioner {self.positioner_id}: speed out of limits.')
+            return False
+
+        log.debug(f'positioner {self.positioner_id}: setting speed '
+                  f'({float(alpha):.2f}, {float(beta):.2f})')
 
         speed_command = self.fps.send_command(CommandID.SET_SPEED,
                                               positioner_id=self.positioner_id,
                                               alpha=float(alpha),
                                               beta=float(beta))
-
         await speed_command
 
         if speed_command.status.failed:
@@ -388,10 +409,6 @@ class Positioner(StatusMixIn):
     async def _goto_position(self, alpha, beta, relative=False):
         """Go to a position."""
 
-        if not self.initialised:
-            log.error(f'positioner {self.positioner_id}: not initialised.')
-            return False
-
         command_id = CommandID.GO_TO_RELATIVE_POSITION \
             if relative else CommandID.GO_TO_ABSOLUTE_POSITION
 
@@ -399,7 +416,6 @@ class Positioner(StatusMixIn):
                                              positioner_id=self.positioner_id,
                                              alpha=float(alpha),
                                              beta=float(beta))
-
         await goto_command
 
         if goto_command.status.failed:
@@ -407,9 +423,7 @@ class Positioner(StatusMixIn):
 
         return goto_command
 
-    async def goto(self, alpha=None, beta=None,
-                   alpha_speed=None, beta_speed=None,
-                   relative=False, force=False):
+    async def goto(self, alpha, beta, speed=None, relative=False, force=False):
         """Moves positioner to a given position.
 
         Parameters
@@ -418,10 +432,8 @@ class Positioner(StatusMixIn):
             The position where to move the alpha arm, in degrees.
         beta : float
             The position where to move the beta arm, in degrees.
-        alpha_speed : float
-            The speed of the alpha arm, in RPM.
-        beta_speed : float
-            The speed of the beta arm, in RPM.
+        speed : tuple
+            The speed of the ``(alpha, beta)`` arms, in RPM on the output.
         relative : bool
             Whether the movement is absolute or relative to the current
             position.
@@ -442,12 +454,13 @@ class Positioner(StatusMixIn):
             >>> await goto(alpha=100, beta=10)
 
             # Set the speed of the alpha arm
-            >>> await goto(alpha_speed=1000)
+            >>> await goto(speed=(1000, 500))
 
         """
 
-        MIN_SPEED = 0
-        MAX_SPEED = 5000
+        async def _restore(original_speed):
+            if original_speed != self.speed:
+                await self.set_speed(*original_speed)
 
         ALPHA_MIN_POSITION = 0
         ALPHA_MAX_POSITION = 360
@@ -458,107 +471,80 @@ class Positioner(StatusMixIn):
             log.error(f'positioner {self.positioner_id}: not initialised.')
             return False
 
-        if not self.fps or not self.fps.pollers.running:
-            log.error(f'positioner {self.positioner_id}: some pollers are not running. '
-                      'Try initialising the positioner.')
-            return False
-
-        if not any([var is not None for var in [alpha, beta, alpha_speed, beta_speed]]):
-            log.error(f'positioner {self.positioner_id}: no inputs.')
+        if not self.fps:
+            log.error('the positioner is not linked to a FPS instance.')
             return False
 
         # Set the speed
-        if alpha_speed is not None or beta_speed is not None:
-
-            if alpha_speed is None or beta_speed is None:
-                log.error(f'positioner {self.positioner_id}: '
-                          'the speed for both arms needs to be provided.')
-                return False
-
-            if (alpha_speed < MIN_SPEED or alpha_speed > MAX_SPEED or
-                    beta_speed < MIN_SPEED or beta_speed > MAX_SPEED):
-                if force:
-                    log.warning(f'positioner {self.positioner_id}: '
-                                'the speed provided is outside the limits '
-                                'but force=True.')
-                else:
-                    log.error(f'positioner {self.positioner_id}: speed out of limits.')
-                    return False
-
-            log.info(f'positioner {self.positioner_id}: setting speed '
-                     f'({float(alpha_speed):.2f}, {float(beta_speed):.2f})')
-
-            if not await self._set_speed(alpha_speed, beta_speed):
-                log.error(f'positioner {self.positioner_id}: failed setting speed.')
-                return False
+        original_speed = self.speed[:]
+        if speed and not await self.set_speed(*speed, force=force):
+            return False
 
         # Go to position
-        if alpha is not None or beta is not None:
+        if (alpha < ALPHA_MIN_POSITION or alpha > ALPHA_MAX_POSITION or
+                beta < BETA_MIN_POSITION or beta > BETA_MAX_POSITION) and not force:
+            log.error(f'positioner {self.positioner_id}: position out of limits.')
+            await _restore(original_speed)
+            return False
 
-            if alpha is None or beta is None:
-                log.error(f'positioner {self.positioner_id}:'
-                          'the position for both arms needs to be provided.')
-                return False
+        log.info(f'positioner {self.positioner_id}: goto position '
+                 f'({float(alpha):.3f}, {float(beta):.3f}) degrees')
 
-            if (alpha < ALPHA_MIN_POSITION or alpha > ALPHA_MAX_POSITION or
-                    beta < BETA_MIN_POSITION or beta > BETA_MAX_POSITION):
-                if force:
-                    log.warning(f'positioner {self.positioner_id}: '
-                                'the position provided is outside the limits '
-                                'but force=True.')
-                else:
-                    log.error(f'positioner {self.positioner_id}: position out of limits.')
-                    return
+        # Stores the QA information in the DB before the move
+        record = self._store_move_qa()
+        if record:
+            record.alpha_move = alpha
+            record.beta_move = beta
+            record.relative = relative
 
-            log.info(f'positioner {self.positioner_id}: goto position '
-                     f'({float(alpha):.3f}, {float(beta):.3f}) degrees')
+        goto_command = await self._goto_position(alpha, beta, relative=relative)
 
-            # Stores the QA information in the DB before the move
-            record = self._store_move_qa()
-            if record:
-                record.alpha_move = alpha
-                record.beta_move = beta
-                record.relative = relative
+        if not goto_command:
+            self._store_move_qa(record, success=False,
+                                fail_reason='CAN command failed')
+            log.error(f'positioner {self.positioner_id}: '
+                      'failed sending the goto position command.')
+            await _restore(original_speed)
+            return False
 
-            goto_command = await self._goto_position(alpha, beta,
-                                                     relative=relative)
+        # Sleeps for the time the firmware believes it's going to take
+        # to get to the desired position.
+        alpha_time, beta_time = goto_command.get_move_time()
 
-            if not goto_command:
-                self._store_move_qa(record, success=False,
-                                    fail_reason='CAN command failed')
-                log.error(f'positioner {self.positioner_id}: '
-                          'failed sending the goto position command.')
-                return False
+        # Update status as soon as we start moving. This clears any possible
+        # DISPLACEMENT_COMPLETED.
+        await asyncio.sleep(0.1)
+        await self.update_status()
 
-            # Sleeps for the time the firmware believes it's going to take
-            # to get to the desired position.
-            alpha_time, beta_time = goto_command.get_move_time()
+        if not self.moving:
+            log.error(f'positioner {self.positioner_id}: positioner is '
+                      'not moving when it should.')
+            return False
 
-            move_time = max([alpha_time, beta_time])
+        self.move_time = max([alpha_time, beta_time])
 
-            log.info(f'positioner {self.positioner_id}: '
-                     f'the move will take {move_time:.2f} seconds')
+        log.info(f'positioner {self.positioner_id}: '
+                 f'the move will take {self.move_time:.2f} seconds')
 
-            # Poll a bit faster during the move.
-            await self.fps.pollers.position.set_delay(1)
-            await asyncio.sleep(move_time)
+        await asyncio.sleep(self.move_time)
 
-            # Blocks until we're sure both arms at at the position.
-            result = await self.wait_for_status(
-                maskbits.PositionerStatus.DISPLACEMENT_COMPLETED,
-                delay=0.1, timeout=3)
+        # Blocks until we're sure both arms at at the position.
+        result = await self.wait_for_status(
+            maskbits.PositionerStatus.DISPLACEMENT_COMPLETED,
+            delay=0.1, timeout=3)
 
-            if result is False:
-                self._store_move_qa(record, success=False,
-                                    fail_reason='Failed to reach position')
-                log.error(f'positioner {self.positioner_id}: '
-                          'failed to reach commanded position.')
-                await self.fps.pollers.position.set_delay()
-                return False
+        if result is False:
+            self._store_move_qa(record, success=False,
+                                fail_reason='Failed to reach position')
+            log.error(f'positioner {self.positioner_id}: '
+                      'failed to reach commanded position.')
+            await _restore(original_speed)
+            return False
 
-            log.info(f'positioner {self.positioner_id}: position reached.')
+        log.info(f'positioner {self.positioner_id}: position reached.')
 
-            self._store_move_qa(record, success=True)
+        self._store_move_qa(record, success=True)
+        await _restore(original_speed)
 
         return True
 

--- a/python/jaeger/positioner.py
+++ b/python/jaeger/positioner.py
@@ -49,6 +49,8 @@ class Positioner(StatusMixIn):
         self.speed = [None, None]
         self.firmware = None
 
+        self._move_time = None
+
         super().__init__(maskbit_flags=maskbits.PositionerStatus,
                          initial_status=maskbits.PositionerStatus.UNKNOWN)
 
@@ -66,6 +68,31 @@ class Positioner(StatusMixIn):
             return False
 
         return self.status.collision
+
+    @property
+    def moving(self):
+        """Returns `True` if the positioner is moving."""
+        return False
+        if (self.status.DISPLACEMENT_COMPLETED not in self.status or
+                self.status.RECEIVING_TRAJECTORY in self.status):
+            return True
+
+        return False
+
+    @property
+    def move_time(self):
+        """Returns the move time."""
+
+        if not self.moving:
+            self._move_time = None
+
+        return self._move_time
+
+    @move_time.setter
+    def move_time(self, value):
+        """Sets the move time."""
+
+        self._move_time = value
 
     @property
     def initialised(self):

--- a/python/jaeger/utils/helpers.py
+++ b/python/jaeger/utils/helpers.py
@@ -294,7 +294,7 @@ class Poller(object):
             original delay."""
 
         if not self.running:
-            raise RuntimeError('poller not running.')
+            return
 
         # Only change delay if the difference is significant.
         if delay and abs(self.delay - delay) < 1e-6:

--- a/python/jaeger/utils/utils.py
+++ b/python/jaeger/utils/utils.py
@@ -8,13 +8,14 @@
 
 import numpy
 
+from jaeger import config
 from jaeger.commands import MOTOR_STEPS
 from jaeger.maskbits import ResponseCode
 
 
 __ALL__ = ['get_dtype_str', 'int_to_bytes', 'bytes_to_int',
            'get_identifier', 'parse_identifier', 'convert_kaiju_trajectory',
-           'motor_steps_to_angle']
+           'motor_steps_to_angle', 'get_goto_move_time']
 
 
 def get_dtype_str(dtype, byteorder='little'):
@@ -332,3 +333,24 @@ def convert_kaiju_trajectory(path, speed=None, step_size=0.03, invert=True):
         beta[:, 1] = -beta[:, 1] + beta[0, 1]
 
     return {'alpha': alpha.tolist(), 'beta': beta.tolist()}
+
+
+def get_goto_move_time(move, speed=None):
+    r"""Returns the time need for a given move, in seconds.
+
+    The move time is calculated as :math:`\dfrac{60 \alpha r}{360 v}` where
+    :math:`\alpha` is the angle, :math:`r` is the reduction ratio, and
+    :math:`v` is the speed in the input in RPM.
+
+    Parameters
+    ----------
+    move : float
+        The move, in degrees.
+    speed : float
+        The speed of the motor for the move, in RPM on the input.
+
+    """
+
+    speed = speed or config['positioner']['motor_speed']
+
+    return move * config['positioner']['reduction_ratio'] / (6. * speed)


### PR DESCRIPTION
Fixes#57: Added `FPS.moving` and `Positioner.moving` attributes to determine whether it is save to move the FPS.


Fixes #56: Move time for go to moves is calculated and reported.

Very significant rewrite of how messages and replies are matched. Now there is a pool of unique identifiers. Each message gets assigned a UID from the pool corresponding to its ``command_id`` and ``positioner_id``. When a reply is received, it is matched based on ``command_id``, ``positioner_id``, and ``UID``. At that point the UID is returned to the pool. Broadcast messages always receive the reserved ``UID=0``. This means that two broadcast of the same command should not be running at the same time or replies could be misassigned.