### PR TITLE
Allow to skip positioners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 🚀 New
 
 * [#149](https://github.com/sdss/jaeger/issues/149) Added an `FPS.goto()` method that sends a list of positioners to a given position using trajectories. By default `Positioner.goto()` now also uses trajectories, but `GOTO_ABSOLUTE_POSITION` can still be used.
+* [#150](https://github.com/sdss/jaeger/issues/150) Allow to skip positioners that are connected to the bus but that we want to ignore. Also allow to disable collision detection for a list of positioners. See configuration options `fps.skip_positioners` and `fps.disable_collision_detection_positioners`.
 
 ## ✨ Improved
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -445,7 +445,7 @@ toml = {version = ">=0.10.2", markers = "python_version > \"3.6\""}
 
 [[package]]
 name = "ipython"
-version = "7.25.0"
+version = "7.26.0"
 description = "IPython: Productive Interactive Computing"
 category = "dev"
 optional = false
@@ -927,7 +927,7 @@ documents = ["sphinx (>=1.1.3)", "sphinx-rtd-theme", "humanfriendly"]
 quality = ["coverage (>=3.5.3)", "nose (>=1.2.1)", "mock (>=1.0.0)", "pep8 (>=1.3.3)"]
 repl = ["click (>=7.0)", "prompt-toolkit (==2.0.4)", "pygments (>=2.2.0)", "click (>=7.0)", "prompt-toolkit (>=3.0.8)", "pygments (>=2.2.0)", "aiohttp (>=3.7.3)", "pyserial-asyncio (>=0.5)"]
 tornado = ["tornado (==4.5.3)"]
-twisted = ["Twisted[conch,serial] (>=20.3.0)", "Twisted[conch] (>=20.3.0)"]
+twisted = ["Twisted[serial,conch] (>=20.3.0)", "Twisted[conch] (>=20.3.0)"]
 
 [[package]]
 name = "pyparsing"
@@ -1150,7 +1150,7 @@ sdsstools = ">=0.2.0"
 
 [[package]]
 name = "sdss-drift"
-version = "0.2.4"
+version = "0.2.5"
 description = "Modbus PLC control library"
 category = "main"
 optional = false
@@ -1722,8 +1722,8 @@ ipdb = [
     {file = "ipdb-0.13.9.tar.gz", hash = "sha256:951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5"},
 ]
 ipython = [
-    {file = "ipython-7.25.0-py3-none-any.whl", hash = "sha256:aa21412f2b04ad1a652e30564fff6b4de04726ce875eab222c8430edc6db383a"},
-    {file = "ipython-7.25.0.tar.gz", hash = "sha256:54bbd1fe3882457aaf28ae060a5ccdef97f212a741754e420028d4ec5c2291dc"},
+    {file = "ipython-7.26.0-py3-none-any.whl", hash = "sha256:892743b65c21ed72b806a3a602cca408520b3200b89d1924f4b3d2cdb3692362"},
+    {file = "ipython-7.26.0.tar.gz", hash = "sha256:0cff04bb042800129348701f7bd68a430a844e8fb193979c08f6c99f28bb735e"},
 ]
 ipython-genutils = [
     {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
@@ -2238,8 +2238,8 @@ sdss-clu = [
     {file = "sdss_clu-1.2.1-py3-none-any.whl", hash = "sha256:c37395e1f1a4992ea54b56b6fe420a0fc05cdb0a20630bafcece815b133ffce1"},
 ]
 sdss-drift = [
-    {file = "sdss-drift-0.2.4.tar.gz", hash = "sha256:a4cc1553c96e69dfbf0e25070ba5a201789d93cbe1bdc6f3ef61d2f75bce2070"},
-    {file = "sdss_drift-0.2.4-py3-none-any.whl", hash = "sha256:a10e1392faf311345d928037871e8e2fc8f17ebf70145d17d75a1cd6c06ac27c"},
+    {file = "sdss-drift-0.2.5.tar.gz", hash = "sha256:483b75d50c8494bb6c4664b7df51324ba6208bc9db063c3543f5bdd34d5b9214"},
+    {file = "sdss_drift-0.2.5-py3-none-any.whl", hash = "sha256:eb9bf7340d689ba3c72293648dd9f1ffa79ef7103047f66dd0bf7c418bceb6a6"},
 ]
 sdsstools = [
     {file = "sdsstools-0.4.10-py3-none-any.whl", hash = "sha256:cb2c78d63fe0418f9a27b534f39f283da027ce3801a9053b221446de00d6adf6"},

--- a/python/jaeger/can.py
+++ b/python/jaeger/can.py
@@ -280,7 +280,7 @@ class JaegerCAN(Generic[Bus_co]):
 
         positioner_id, command_id, reply_uid, __ = parse_identifier(msg.arbitration_id)
 
-        if positioner_id in config["fps"]["skipped_positioners"]:
+        if positioner_id in config["fps"]["skip_positioners"]:
             return
 
         if command_id == CommandID.COLLISION_DETECTED:

--- a/python/jaeger/can.py
+++ b/python/jaeger/can.py
@@ -280,6 +280,9 @@ class JaegerCAN(Generic[Bus_co]):
 
         positioner_id, command_id, reply_uid, __ = parse_identifier(msg.arbitration_id)
 
+        if positioner_id in config["fps"]["skipped_positioners"]:
+            return
+
         if command_id == CommandID.COLLISION_DETECTED:
 
             log.error(

--- a/python/jaeger/etc/jaeger.yml
+++ b/python/jaeger/etc/jaeger.yml
@@ -45,6 +45,8 @@ fps:
     start_pollers: false
     status_poller_delay: 5
     position_poller_delay: 5
+    skipped_positioners: []
+    disable_collision_detection_positioners: []
 
 positioner:
     reduction_ratio: 1024

--- a/python/jaeger/etc/jaeger.yml
+++ b/python/jaeger/etc/jaeger.yml
@@ -45,7 +45,7 @@ fps:
     start_pollers: false
     status_poller_delay: 5
     position_poller_delay: 5
-    skipped_positioners: []
+    skip_positioners: []
     disable_collision_detection_positioners: []
 
 positioner:

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -342,7 +342,7 @@ class FPS(BaseFPS):
         for reply in get_firmware_command.replies:
             if reply.positioner_id not in self.positioners:
 
-                if reply.positioner_id in config["fps"]["skipped_positioners"]:
+                if reply.positioner_id in config["fps"]["skip_positioners"]:
                     continue
 
                 if hasattr(reply.message, "interface"):

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -341,6 +341,10 @@ class FPS(BaseFPS):
         # positioner was not in the list, adds it.
         for reply in get_firmware_command.replies:
             if reply.positioner_id not in self.positioners:
+
+                if reply.positioner_id in config["fps"]["skipped_positioners"]:
+                    continue
+
                 if hasattr(reply.message, "interface"):
                     interface = reply.message.interface
                     bus = reply.message.bus
@@ -422,6 +426,18 @@ class FPS(BaseFPS):
             warnings.warn(
                 f"Safe mode enabled. Minimum beta is {min_beta} degrees.",
                 JaegerUserWarning,
+            )
+
+        # Disable collision detection for listed robots.
+        disable_collision = config["fps"]["disable_collision_detection_positioners"]
+        if len(disable_collision):
+            await self.send_command(
+                CommandID.ALPHA_CLOSED_LOOP_WITHOUT_COLLISION_DETECTION,
+                positioner_ids=disable_collision,
+            )
+            await self.send_command(
+                CommandID.BETA_CLOSED_LOOP_WITHOUT_COLLISION_DETECTION,
+                positioner_ids=disable_collision,
             )
 
         # Start the pollers


### PR DESCRIPTION
This PR allows to:

- Skip positioners that are connected to the bus but that we want to ignore.
- Disable collision detection for a list of positioners.