### PR TITLE
Disable Hall sensors on idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ## 🚀 New
 
-* Add commands 45, 104, and 105 for hall sensor calibration querying.
+* Add commands `GET_HALL_CALIB_ERROR`, `GET_ALPHA_HALL_CALIB`, and `GET_BETA_HALL_CALIB` for Hall sensor calibration querying.
 
 ## ✨ Improved
 
+* [#151](https://github.com/sdss/jaeger/pull/151) Disable Hall sensors on initialise and turn them on only during a trajectory.
 * Add `Trajectory.start_time` and `Trajectory.end_time` that can be used to determine when the trajectory failed. `send_trajectory` now allows to return the unsent or non-started trajectory.
 * When running the actor as a daemon in detached mode, log stdout and stderr to file.
 * By default, do not fail when a command receives an `UNKNOWN_COMMAND` reply; this usually means that the positioner firmware does not support that command yet. This can be disabled by initialising the `Command` with `ignore_unknown=False`.

--- a/python/jaeger/commands/trajectory.py
+++ b/python/jaeger/commands/trajectory.py
@@ -502,6 +502,7 @@ class Trajectory(object):
             if restart_pollers:
                 self.fps.pollers.start()
             if self.disable_halls:
+                log.debug("Turning off Hall sensors.")
                 await self.fps.send_command(
                     CommandID.HALL_OFF,
                     positioner_ids=positioner_ids,

--- a/python/jaeger/commands/trajectory.py
+++ b/python/jaeger/commands/trajectory.py
@@ -130,7 +130,7 @@ async def send_trajectory(
     if start_trajectory is False:
         return traj
 
-    log.info("starting trajectory ...")
+    log.info("Starting trajectory ...")
     try:
         await traj.start(use_sync_line=use_sync_line)
     except TrajectoryError as err:
@@ -424,8 +424,11 @@ class Trajectory(object):
         for positioner_id in positioner_ids:
             self.fps[positioner_id].move_time = self.move_time
 
-        log.debug("Turning on Hall sensors.")
+        log.debug("Turning Hall sensors on.")
         await self.fps.send_command(CommandID.HALL_ON, positioner_ids=positioner_ids)
+
+        # Need to wait five seconds before Halls are reliably on.
+        await asyncio.sleep(5)
 
         if use_sync_line:
 

--- a/python/jaeger/fps.py
+++ b/python/jaeger/fps.py
@@ -442,6 +442,9 @@ class FPS(BaseFPS):
                 positioner_ids=disable_collision,
             )
 
+        # Disable Hall sensors while on idle to save power.
+        await self.send_command(CommandID.HALL_OFF)
+
         # Start the pollers
         if start_pollers and not self.is_bootloader():
             self.pollers.start()


### PR DESCRIPTION
To save power.

- Turns off Hall sensors on initialise.
- Enables them during a trajectory, then disables them again.