### PR TITLE
Tweaks to FVC class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 * Added additional checks to confirm that a trajectory starts correctly and succeeds. After one second, the code checks that the FPS is moving and that `DISPLACEMENT_COMPLETED` is not present on any positioner status. At the end of the trajectory a check confirms that all the positioners are within 0.1 degrees of their destinations.
 * Add `--no-gfas` to the `ieb power on` command to avoid powering the GFAs during the power on sequence.
+* Allows to call `FVC.expose()` without an active command by creating an ad-hoc Tron connection.
+* Allows to use fibre_type other than 'Metrology' when processing an FVC image.
+* Defaults to `proc-<image>` when calling `FVC.write_proc_image()`.
 
 
 ## 0.11.0 - October 12, 2021

--- a/python/jaeger/fvc.py
+++ b/python/jaeger/fvc.py
@@ -492,8 +492,8 @@ class FVC:
             new.loc[pos_na, ["alpha_measured", "beta_measured"]] = expected.to_numpy()
             new.loc[pos_na, "conversion_valid"] = 0
 
-        new["alpha_offset"] = k * (new["alpha_expected"] - new["alpha_measured"])
-        new["beta_offset"] = k * (new["beta_expected"] - new["beta_measured"])
+        new["alpha_offset"] = self.k * (new["alpha_expected"] - new["alpha_measured"])
+        new["beta_offset"] = self.k * (new["beta_expected"] - new["beta_measured"])
 
         new["alpha_new"] = new["alpha_reported"] + new["alpha_offset"]
         new["beta_new"] = new["beta_reported"] + new["beta_offset"]

--- a/python/jaeger/fvc.py
+++ b/python/jaeger/fvc.py
@@ -167,6 +167,7 @@ class FVC:
         self,
         path: pathlib.Path | str,
         fibre_data: Optional[pandas.DataFrame] = None,
+        fibre_type: str = "Metrology",
         plot: bool | str = False,
         polids: numpy.ndarray | list | None = None,
     ) -> tuple[fits.ImageHDU, pandas.DataFrame, pandas.DataFrame]:
@@ -178,11 +179,13 @@ class FVC:
             The path to the raw FVC image.
         fibre_data
             A Pandas data frame with the expected coordinates of the targets. It
-            is expected the data frame will have columns ``positioner_id``,
-            ``fibre_type``, ``xwok``, and ``ywok``. Only the rows that correspond
-            to ``fibre_type='Metrology'`` are used. This frame is appended to the
+            is expected the data frame will have columns ``hole_id``,
+            ``fibre_type``, ``xwok``, and ``ywok``. This frame is appended to the
             processed image. Normally this parameters is left empty and the fibre
             table from the configuration loaded into the FPS instace is used.
+        fibre_type
+            The ``fibre_type`` rows in ``fibre_data`` to use. Defaults to
+            ``fibre_type='Metrology'``.
         plot
             Whether to save additional debugging plots along with the processed image.
             If ``plot`` is a string, it will be used as the directory to which to
@@ -242,7 +245,7 @@ class FVC:
 
         xyCCD = self.centroids[["x", "y"]].to_numpy()
 
-        fibre_data_met = self.fibre_data.loc["Metrology"]
+        fibre_data_met = self.fibre_data.loc[fibre_type]
 
         # Get close enough to associate the correct centroid with the correct fiducial.
         x_wok_expect = numpy.concatenate([xCMM, fibre_data_met.xwok.to_numpy()])
@@ -357,12 +360,12 @@ class FVC:
         )
         xy_wok_robot_meas = xy_wok_meas[arg_found]
 
-        self.fibre_data.loc["Metrology", "xwok_measured"] = xy_wok_robot_meas[:, 0]
-        self.fibre_data.loc["Metrology", "ywok_measured"] = xy_wok_robot_meas[:, 1]
+        self.fibre_data.loc[fibre_type, "xwok_measured"] = xy_wok_robot_meas[:, 0]
+        self.fibre_data.loc[fibre_type, "ywok_measured"] = xy_wok_robot_meas[:, 1]
 
         # Only use online robots for final RMS.
         online = self.fibre_data.loc[
-            (self.fibre_data.index == "Metrology") & (self.fibre_data.offline == 0)
+            (self.fibre_data.index == fibre_type) & (self.fibre_data.offline == 0)
         ]
         dx = online.xwok - online.xwok_measured
         dy = online.ywok - online.ywok_measured

--- a/python/jaeger/fvc.py
+++ b/python/jaeger/fvc.py
@@ -139,6 +139,7 @@ class FVC:
 
         self.log(f"Taking {exposure_time} s FVC exposure.", to_command=False)
 
+        tron = None
         cmd_str = f"talk -c fvc expose {exposure_time}"
 
         if self.command:
@@ -148,10 +149,14 @@ class FVC:
                 config["actor"]["tron_host"],
                 config["actor"]["tron_port"],
             )
+            await tron.start()
             expose_command = tron.send_command("fliswarm", cmd_str)
 
         assert isinstance(expose_command, Command)
         await expose_command
+
+        if tron:
+            tron.stop()
 
         if expose_command.status.did_fail:
             raise FVCError("The FVC exposure failed.")

--- a/python/jaeger/fvc.py
+++ b/python/jaeger/fvc.py
@@ -545,7 +545,7 @@ class FVC:
 
         for key in ieb_keys:
             device_name = ieb_keys[key]
-            if self.fps and self.fps.ieb and isinstance(self.fps.ieb, IEB):
+            if self.fps and isinstance(self.fps.ieb, IEB):
                 try:
                     device = self.fps.ieb.get_device(device_name)
                     ieb_data[key] = (await device.read())[0] or -999.0
@@ -623,7 +623,7 @@ class FVC:
             positioner = self.fps[robot.id]
             robot.setDestinationAlphaBeta(positioner.alpha, positioner.beta)
 
-            row: pandas.Series = offsets.loc[robot.id, ["alpha_new", "beta_new"]]
+            row = offsets.loc[robot.id, ["alpha_new", "beta_new"]]
             if row.isna().any():
                 log.warning(f"Positioner {robot.id}: new position is NaN. Skipping.")
                 robot.setAlphaBeta(positioner.alpha, positioner.beta)


### PR DESCRIPTION
- Allows to call `expose()` without an active command.
- Allows to use ``fibre_type`` other than `'Metrology'`.
- Defaults to `proc-<image>` when calling `write_proc_image()`.