### PR TITLE
FVC snapshot command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#184](https://github.com/sdss/jaeger/issues/184) Added a `jaeger.fvc.reprocess_configuration()` coroutine that allows to reprocess the final FVC image for a configuration with a different centroid method.
 * Add `jaeger configuration reload` command. It's equivalent to using `jaeger configuration load --no-clone DESIGNID` where `DESIGNID` is the currently loaded design.
 * If called without arguments, `disable` now outputs the list of currently disabled robots.
+* New command `fvc snapshot` that creates a temporary configuration from the current positions and takes an FVC measurement.
 
 ### ✨ Improved
 

--- a/python/jaeger/actor/commands/fvc.py
+++ b/python/jaeger/actor/commands/fvc.py
@@ -419,7 +419,11 @@ async def take_fvc_loop(
         command.debug("Turning LEDs off.")
         await command.send_command("jaeger", "ieb fbi led1 led2 0")
 
-        if no_write_summary is False and failed is False:
+        if (
+            not isinstance(fps.configuration, ManualConfiguration)
+            and no_write_summary is False
+            and failed is False
+        ):
             command.info("Saving confSummaryF file.")
             await fvc.write_summary_F()
 

--- a/python/jaeger/actor/commands/fvc.py
+++ b/python/jaeger/actor/commands/fvc.py
@@ -255,7 +255,13 @@ async def snapshot(command: JaegerCommandType, fps: FPS):
     positions = fps.get_positions_dict()
     configuration = ManualConfiguration.create_from_positions(positions)
 
-    result = await take_fvc_loop(command, fps, apply=False, configuration=configuration)
+    result = await take_fvc_loop(
+        command,
+        fps,
+        apply=False,
+        configuration=configuration,
+        no_write_summary=True,
+    )
 
     return command.finish() if result is True else command.fail()
 

--- a/python/jaeger/fvc.py
+++ b/python/jaeger/fvc.py
@@ -38,6 +38,7 @@ from jaeger.utils import run_in_executor
 
 if TYPE_CHECKING:
     from jaeger.actor import JaegerActor
+    from jaeger.target.configuration import BaseConfiguration
 
 
 __all__ = ["FVC"]
@@ -50,6 +51,7 @@ DEFAULT_CENTROID_METHOD = "zbplus"
 class FVC:
     """Focal View Camera class."""
 
+    configuration: Optional[BaseConfiguration]
     fibre_data: Optional[pandas.DataFrame]
     measurements: Optional[pandas.DataFrame]
     centroids: Optional[pandas.DataFrame]
@@ -84,6 +86,7 @@ class FVC:
     def reset(self):
         """Resets the instance."""
 
+        self.configuration = None
         self.fvc_transform: FVCTransformAPO | None = None
         self.fibre_data = None
         self.centroids = None
@@ -197,6 +200,7 @@ class FVC:
         self,
         path: pathlib.Path | str,
         positioner_coords: dict,
+        configuration: Optional[BaseConfiguration] = None,
         fibre_data: Optional[pandas.DataFrame] = None,
         fibre_type: str = "Metrology",
         centroid_method: str | None = None,
@@ -213,6 +217,9 @@ class FVC:
         positioner_coords
             A dictionary of positioner ID to ``(alpha, beta)`` with the current
             positions of the robots.
+        configuration
+            A configuration object to use for processing. If `None`, defaults to the
+            current `.FPS` loaded configuration.
         fibre_data
             A Pandas data frame with the expected coordinates of the targets. It
             is expected the data frame will have columns ``positioner_id``,
@@ -252,10 +259,12 @@ class FVC:
         if not os.path.exists(path):
             raise FVCError(f"FVC image {path} does not exist.")
 
+        self.configuration = configuration or self.fps.configuration
+
         if fibre_data is None:
-            if self.fps is None or self.fps.configuration is None:
+            if configuration is None:
                 raise FVCError("No fibre data and no configuration has been loaded.")
-            fibre_data = self.fps.configuration.assignment_data.fibre_table
+            fibre_data = configuration.assignment_data.fibre_table
 
         fdata = fibre_data.copy().reset_index().set_index("positioner_id")
 
@@ -645,8 +654,8 @@ class FVC:
 
         proc_hdus = fits.HDUList([fits.PrimaryHDU(), self.proc_hdu])
 
-        if self.fps and self.fps.configuration:
-            proc_hdus[1].header["CONFIGID"] = self.fps.configuration.configuration_id
+        if self.configuration:
+            proc_hdus[1].header["CONFIGID"] = self.configuration.configuration_id
         else:
             proc_hdus[1].header["CONFIGID"] = -999.0
 
@@ -721,8 +730,8 @@ class FVC:
             current_positions["startAlpha"] = numpy.nan
             current_positions["startBeta"] = numpy.nan
 
-            if self.fps.configuration:
-                robot_grid = self.fps.configuration.robot_grid
+            if self.configuration:
+                robot_grid = self.configuration.robot_grid
 
                 _cmd_alpha = []
                 _cmd_beta = []
@@ -842,7 +851,7 @@ class FVC:
     ):
         """Updates data with the last measured positions and write confSummaryF."""
 
-        if self.fps is None or self.fps.configuration is None:
+        if self.configuration is None:
             raise FVCError("write_summary_F can only be called with a configuration.")
 
         if self.fibre_data is None:
@@ -871,7 +880,7 @@ class FVC:
             if not numpy.isnan(alpha):
                 fdata.loc[idx[pid, :], ["alpha", "beta"]] = (alpha, beta)
 
-        configuration_copy = self.fps.configuration.copy()
+        configuration_copy = self.configuration.copy()
         configuration_copy.assignment_data.fibre_table = fdata.copy()
 
         for pid in measured.index.get_level_values(0).tolist():
@@ -909,7 +918,7 @@ class FVC:
 
         # Plot analysis of FVC loop.
         if plot and self.proc_image_path:
-            if self.fps.configuration.assignment_data.boresight is None:
+            if self.configuration.assignment_data.boresight is None:
                 self.log(
                     "Configuration does not have boresight set. "
                     "Cannot produce FVC plots.",
@@ -921,7 +930,7 @@ class FVC:
                 outpath = str(self.proc_image_path).replace(".fits", "_distances.pdf")
 
                 plot_fvc_distances(
-                    self.fps.configuration,
+                    self.configuration,
                     configuration_copy.assignment_data.fibre_table,
                     path=outpath,
                 )
@@ -982,8 +991,8 @@ async def reprocess_configuration(
     fps = FPS.get_instance()
     assert not fps.can, "This function cannot be called on a running FPS instance."
 
-    fps.configuration = design.configuration
-    fps.configuration.configuration_id = configuration_id
+    configuration = design.configuration
+    configuration.configuration_id = configuration_id
 
     fvc = FVC(site)
 
@@ -1000,6 +1009,7 @@ async def reprocess_configuration(
     fvc.process_fvc_image(
         fimg,
         positioner_coords,
+        configuration=configuration,
         fibre_data=fiber_data,
         centroid_method=centroid_method,
         plot=False,


### PR DESCRIPTION
This PR is an initial step in a larger change that would take an FVC measurement after a collision detected and provide information about the likelihood of that collision being real.

These changes refactor the `fvc loop` command, moving the logic to a separate function. It also allows to use any `BaseConfiguration` object with the `FVC` class. Finally, it introduces an `fvc snapshot` command that creates a configuration from the current positions and takes the equivalent of an `fvc loop --no-apply`.