### PR TITLE
Report timed out commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Next version
+
+### ✨ Improved
+
+* [#195](https://github.com/sdss/jaeger/issues/195) Prevent late replies to timed out commands to flood the log/actor window. The errors are now redirected only to the CAN log. Timed out commands are reported unless the command is a broadcast with the number of replies not defined.
+
+
 ## 1.3.0 - January 2, 2023
 
 ### ✨ Improved

--- a/python/jaeger/commands/base.py
+++ b/python/jaeger/commands/base.py
@@ -435,7 +435,7 @@ class Command(StatusMixIn[CommandStatus], Future_co):
             self._log(
                 f"received a reply from {pid} but the command has already timed out.",
                 level=logging.ERROR,
-                logs=[log, can_log],
+                logs=[can_log],
             )
             return
         elif self.status == CommandStatus.CANCELLED:
@@ -536,6 +536,12 @@ class Command(StatusMixIn[CommandStatus], Future_co):
             elif self.status.failed:
                 level = logging.ERROR if not silent else logging.DEBUG
                 self._log(f"command finished with status {self.status.name!r}", level)
+            elif self.status.timed_out and self._n_replies is not None:
+                # Report the command timed out, but only if this is not a broadcast
+                # and the number expected replies is not known. In those cases the
+                # command will always time out and that's expected.
+                level = logging.ERROR if not silent else logging.DEBUG
+                self._log("command timed out.", level)
 
             # For good measure we return all the UIDs
             if self.is_broadcast:


### PR DESCRIPTION
When a command has timed out and receives late replies from some positioners, the log window may be flooded by messages like

```
text="[GET_ACTUAL_POSITION, [233, 436, 160, 16, 310, 260, 264, 192, 325, 440, 396, 333, 466, 469, 503, 343, 627, 533, 550, 383, 639, 552, 597, 483, 789, 565, 599, 514, 820, 664, 691, 588, 979, 669, 733, 674, 983, 766, 761, 710, 990, 776, 802, 741, 1026, 795, 886, 793, 1032, 875, 920, 809, 422, 322, 40, 228, 199, 409, 296, 361, 481, 448, 372, 417, 495, 566, 402, 488, 506, 572, 452, 548, 580, 598, 730, 575, 623, 619, 827, 604, 648, 630, 866, 605, 716, 635, 885, 654, 717, 638, 901, 814, 721, 668, 903, 857, 760, 757, 940, 877, 818, 781, 954, 894, 904, 786, 986, 895, 956, 840, 1034, 964, 963, 849, 1070, 973, 985, 906, 1176, 1044, 1028, 910, 1241, 1190, 1037, 1069, 1287, 1252, 1040, 1126, 1365, 1364, 1049, 1300, 1376, 1382, 515, 450, 200, 375, 52, 493, 432, 507, 63, 501, 600, 613, 261, 577, 626, 678, 460, 689, 660, 706, 475, 692, 671, 784, 681, 693, 724, 805, 694, 698, 779, 830, 719, 709, 806, 847, 758, 762, 819, 870, 790, 765, 832, 872, 816, 787, 837, 932, 825, 835, 938, 984, 898, 868, 942, 999, 908, 899, 951, 1019, 912, 921, 997, 1036, 965, 936, 1016, 1091, 1017, 1013, 1023, 1109, 1111, 1043, 1046, 1125, 1240, 1301, 1094, 1155, 1329, 1096, 1370, 1200, 891, 971, 839, 1222, 995, 994, 846, 1272, 1011, 1012, 914, 1323, 1202, 1095, 1098, 1342, 1260, 1213, 1144, 1346, 1281, 1226, 1354, 1290, 1251, 1246, 1357, 1285, 1267, 56, 103, 117, 535, 71, 146, 188, 119, 144, 147, 201, 194, 167, 153, 288, 307, 179, 177, 380, 592, 189, 238, 386, 624, 208, 415, 410, 647, 1078, 824, 423, 650, 1083, 897, 425, 663, 1121, 1054, 478, 667, 1167, 1068, 489, 673, 1170, 1103, 743, 695, 1172, 1105, 905, 859, 1296, 1135, 935, 880, 1308, 1143, 944, 1063, 1339, 1151, 962, 1142, 1341, 1152, 1018, 1148, 1347, 1162, 1039, 1174, 1351, 1276, 1137, 1203, 1374, 1331, 1373, 1355, 1391, 1378, 1396, 124, 78, 615, 110, 136, 115, 86, 637, 148, 120, 171, 677, 676, 140, 187, 707, 865, 202, 222, 756, 948, 214, 240, 808, 1106, 251, 298, 838, 1140, 289, 1056, 916, 1150, 373, 1085, 918, 1153, 587, 1163, 919, 1187, 661, 1192, 925, 1207, 1108, 1317, 1004, 1303, 1112, 1324, 1009, 1316, 1129, 1328, 1025, 1336, 1130, 1349, 1104, 1338, 1169, 1353, 1107, 1359, 1194, 1362, 1118, 1363, 1306, 1383, 1127, 1381, 1312, 1384, 1149, 1388, 1318, 1392, 1314, 1400, 1372, 1393, 1330, 204, 245, 751, 792, 170, 544, 126, 3, 256, 554, 130, 107, 302, 610, 138, 114, 455, 631, 155, 129, 581, 641, 215, 159, 640, 675, 285, 162, 665, 687, 394, 275, 690, 714, 523, 293, 715, 748, 950, 589, 742, 804, 996, 941, 753, 871, 1086, 1058, 796, 896, 1100, 1092, 828, 975, 1114, 1101, 831, 1051, 1115, 1131, 842, 1081, 1232, 1156, 943, 1113, 1256, 1158, 989, 1215, 1264, 1229, 991, 1266, 1289, 1302, 1000, 1334, 1326, 1333, 1208, 1345, 1358], 36231]: received a reply from 877 but the command has already timed out."
```

This PR changes the logging of those errors so that they go to the CAN log but not to the normal log, which is redirected to the actor.

It also reports when a command has timed out, but not if the command is a broadcast with `n_positioners` not defined, in which case a time out is expected.