### PR TITLE
Retry up to 3 times if no light found in FVC image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next version
 
+### 🚑 Hotfix
+
+* [#205](https://github.com/sdss/jaeger/pull/205) Added a hotfix for an issue caused when the back-illuminated fibres don't turn on during and FVC loop (cause under investigation). When light is not detected in the FVC image the code will retry up to three times, each time turning the LEDs off and then on again.
+
 ### ⚙️ Engineering
 
 * Add back `pyarrow` dependency.


### PR DESCRIPTION
This is a hotfix for cases when the FPIs fail to turn on. If one of the errors indicating that there is no light in the FVC image are detected, the code will retry up to three times (turning off the LEDs before retrying) before giving up.