### PR TITLE
add sea-anemone configuration option to random config command

### DIFF
--- a/src/jaeger/actor/commands/configuration.py
+++ b/src/jaeger/actor/commands/configuration.py
@@ -967,6 +967,11 @@ async def slew(
 @click.argument("SEED", type=int, required=False)
 @click.option("--danger", is_flag=True, help="Use full range of alpha and beta.")
 @click.option(
+    "--sea-anemone",
+    is_flag=True,
+    help="Points robots radially outward...with a touch of randomness"
+)
+@click.option(
     "--uniform",
     type=str,
     default=None,
@@ -1003,6 +1008,7 @@ async def random(
     send_trajectory: bool = True,
     max_retries: int = 10,
     path_generation_mode: str | None = None,
+    sea_anemone: bool = False
 ):
     """Executes a random, valid configuration."""
 
@@ -1044,6 +1050,7 @@ async def random(
             safe=not danger,
             collision_buffer=collision_buffer,
             max_retries=max_retries,
+            sea_anemone=sea_anemone,
         )
 
         command.info("Getting trajectory.")

--- a/src/jaeger/actor/commands/configuration.py
+++ b/src/jaeger/actor/commands/configuration.py
@@ -969,7 +969,7 @@ async def slew(
 @click.option(
     "--sea-anemone",
     is_flag=True,
-    help="Points robots radially outward...with a touch of randomness"
+    help="Points robots radially outward...with a touch of randomness",
 )
 @click.option(
     "--uniform",
@@ -1008,7 +1008,7 @@ async def random(
     send_trajectory: bool = True,
     max_retries: int = 10,
     path_generation_mode: str | None = None,
-    sea_anemone: bool = False
+    sea_anemone: bool = False,
 ):
     """Executes a random, valid configuration."""
 

--- a/src/jaeger/target/tools.py
+++ b/src/jaeger/target/tools.py
@@ -104,6 +104,7 @@ async def create_random_configuration(
     n_failed: int = 0,
     max_retries: int = 5,
     path_generation_mode: str | None = None,
+    sea_anemone: bool = False,
     **kwargs,
 ):
     """Creates a random configuration using Kaiju."""
@@ -122,7 +123,20 @@ async def create_random_configuration(
         if robot.isOffline:
             continue
 
-        if uniform is not None:
+        if sea_anemone:
+            # configuration with robot arms mostly extended
+            # and pointing generally radially outward
+            # intended for fvc calibration
+            theta = numpy.degrees(numpy.arctan2(robot.yPos, robot.xPos))
+            alpha = (theta + 90) % 360
+            if alpha < 5:
+                alpha = 5
+            if alpha > 355:
+                alpha = 355
+
+            robot.setAlphaBeta(alpha + numpy.random.uniform(-3, 3), 9)
+
+        elif uniform is not None:
             alpha0, alpha1, beta0, beta1 = uniform
             robot.setAlphaBeta(
                 numpy.random.uniform(alpha0, alpha1),


### PR DESCRIPTION
Add a different type of random config option.  --sea-anemone flag will stretch robots radially, to use for fvc calibration with rotator scans.